### PR TITLE
Clock header

### DIFF
--- a/api/app.tsx
+++ b/api/app.tsx
@@ -4,7 +4,7 @@
    ADDRESS ON LINE 7
 */
 
-const ipAddress = [ '192.168.0.53', '192.168.1.82', '10.11.87.119'];
+const ipAddress = [ '192.168.0.53', '192.168.1.82', '10.11.105.156'];
 
 var express = require("express");
 const app = express();
@@ -121,7 +121,6 @@ io.on('connection', (socket) => {
     socket.on('ScenarioClock', (props) => {
         console.log(props.message);
         io.sockets.emit('ScenarioClockAPI',props);
-        console.log("API: Emitted the message back out.")
     })
 
     socket.on('JOIN', (server, team) => {

--- a/api/app.tsx
+++ b/api/app.tsx
@@ -27,109 +27,266 @@ app.use(express.json())
 
 http.listen(port, () => console.log(`API listening on port ${port}.`));
 
+
 io.on('connection', (socket) => {
-    console.log(socket.id)
+    const Patch = (table, update) => {
+        if(table == 'equipment') {
+            const id = update.id;
+            delete update.id;
+            const room = `${update.server}_${update.team}`;
+            knex('equipment')
+                .where('id', id)
+                .update(update)
+                .then(res => {
+                    knex('equipment')
+                        .select('*')
+                        .where('team', update.team)
+                        .andWhere('server', update.server)
+                        .then(data => socket.to(room).emit('equipment_patch', data))
+                });
+        } else if(table == 'satEnv') {
+            const conn = update.conn;
+            delete update.id;
+            const room = update.server;
+            knex('satenv')
+                .where('conn', conn)
+                .update(update)
+                .then(res => {
+                    knex('satenv')
+                        .select('*')
+                        .where('server', update.server)
+                        .then(data => socket.to(room).emit('satEnv_patch', data))
+                });
+        };
+    };
+
+    const Delete = (table, update) => {
+        if(table == 'equipment') {
+            const id = update.id;
+            const room = update.server;
+            delete update.id;
+            knex('equipment')
+                .where('id', id)
+                .delete()
+                .then(res => {
+                    knex('equipment')
+                        .select('*')
+                        .where('team', update.team)
+                        .andWhere('server', update.server)
+                        .then(data => socket.to(room).emit('equipment_patch', data))
+                });
+        } else if(table == 'satEnv') {
+            const conn = update.conn;
+            const room = update.server;
+            delete update.id;
+            knex('satenv')
+                .where('conn', conn)
+                .delete()
+                .then(res => {
+                    knex('satenv')
+                        .select('*')
+                        .where('server', update.server)
+                        .then(data => socket.to(room).emit('satEnv_patch', data))
+                });
+        };
+    };
+
+    const Post = (table, update) => {
+        if(table == 'equipment') {
+            const room = `${update.server}_${update.team}`;
+            delete update.id;
+            knex('equipment')
+                .insert(update)
+                .then(res => {
+                    knex('equipment')
+                        .select('*')
+                        .where('team', update.team)
+                        .andWhere('server', update.server)
+                        .then(data => socket.to(room).emit('equipment_patch', data))
+                });
+        } else if(table == 'satEnv') {
+            const room = update.server;
+            delete update.id;
+            knex('satenv')
+                .insert(update)
+                .then(res => {
+                    knex('satenv')
+                        .select('*')
+                        .where('server', update.server)
+                        .then(data => socket.to(room).emit('satEnv_patch', data))
+                });
+        };
+    };
+
     socket.on('JOIN', (server, team) => {
         socket.join(server)
         socket.join(`${server}_${team}`)
-        console.log(server, team)
     });
 
     socket.on('CHAT', (props) => {
         const room = props.server;
-        console.log(props)
         io.sockets.emit('CHAT_API', props);
     });
 
-    socket.on('PATCH', (table, update) => {
-        if(table == 'equipment') {
-            console.log(update)
-            const id = update.id;
-            delete update.id;
-            const room = `${update.server}_${update.team}`;
-            knex('equipment')
-                .where('id', id)
-                .update(update)
-                .then(res => {
-                    knex('equipment')
-                        .select('*')
-                        .where('team', update.team)
-                        .andWhere('server', update.server)
-                        .then(data => socket.to(room).emit('equipment_patch', data))
-                });
-        } else if(table == 'satEnv') {
-            const conn = update.conn;
-            delete update.id;
-            const room = update.server;
-            console.log(update)
-            knex('satenv')
-                .where('conn', conn)
-                .update(update)
-                .then(res => {
-                    knex('satenv')
-                        .select('*')
-                        .where('server', update.server)
-                        .then(data => socket.to(room).emit('satEnv_patch', data))
-                });
-        };
+    socket.on('POST', (table, update) => {
+        Post(table, update)
     });
 
-    socket.on('POST', (table, update) => {
-        if(table == 'equipment') {
-            const room = `${update.server}_${update.team}`;
-            delete update.id;
-            knex('equipment')
-                .insert(update)
-                .then(res => {
-                    knex('equipment')
-                        .select('*')
-                        .where('team', update.team)
-                        .andWhere('server', update.server)
-                        .then(data => socket.to(room).emit('equipment_patch', data))
-                });
-        } else if(table == 'satEnv') {
-            const room = update.server;
-            delete update.id;
-            knex('satenv')
-                .insert(update)
-                .then(res => {
-                    knex('satenv')
-                        .select('*')
-                        .where('server', update.server)
-                        .then(data => socket.to(room).emit('satEnv_patch', data))
-                });
-        };
+    socket.on('PATCH', (table, update) => {
+        Patch(table, update)
     });
 
     socket.on('DELETE', (table, update) => {
-        if(table == 'equipment') {
-            const id = update.id;
-            const room = update.server;
-            delete update.id;
-            knex('equipment')
-                .where('id', id)
-                .delete()
-                .then(res => {
-                    knex('equipment')
-                        .select('*')
-                        .where('team', update.team)
-                        .andWhere('server', update.server)
-                        .then(data => socket.to(room).emit('equipment_patch', data))
+        Delete(table, update);
+    });
+
+    socket.on('RESET', (server) => {
+        // Delete all student signals from environment
+        knex('satenv')
+            .select('*')
+            .where('server', server)
+            .andWhereNot('team', 'Instructor')
+            .then(res => {
+                res.forEach(signal => Delete('satEnv', signal));
+            });
+
+        // Reset all TX modems
+        knex('equipment')
+            .select('*')
+            .where('server', server)
+            .andWhereNot('team', 'Instructor')
+            .andWhere('unit_type', 'TX')
+            .then(res => {
+                res.forEach(modem => {
+                    const tmpModem = {
+                        ...modem,
+                        cf: 1000,
+                        dr: 1,
+                        mod: 1,
+                        fec: 1,
+                        power: -87,
+                        sat: 'ASH',
+                        active: false
+                    };
+                    Patch('equipment', tmpModem);
                 });
-        } else if(table == 'satEnv') {
-            const conn = update.conn;
-            const room = update.server;
-            delete update.id;
-            knex('satenv')
-                .where('conn', conn)
-                .delete()
-                .then(res => {
-                    knex('satenv')
-                        .select('*')
-                        .where('server', update.server)
-                        .then(data => socket.to(room).emit('satEnv_patch', data))
+            });
+        
+        // Reset all RX modems
+        knex('equipment')
+            .select('*')
+            .where('server', server)
+            .andWhereNot('team', 'Instructor')
+            .andWhere('unit_type', 'RX')
+            .then(res => {
+                res.forEach(modem => {
+                    const tmpModem = {
+                        ...modem,
+                        cf: 1000,
+                        mod: 1,
+                        fec: 1,
+                    };
+                    Patch('equipment', tmpModem);
                 });
-        };
+            });
+        
+        // Reset all Antennas
+        knex('equipment')
+            .select('*')
+            .where('server', server)
+            .andWhere('unit_type', 'Antenna')
+            .then(res => {
+                res.forEach(antenna => {
+                    const tmpAntenna = {
+                        ...antenna,
+                        unit_name: 'C',
+                        cf: 0,
+                        bw: 0,
+                        mod: 0,
+                        fec: 0,
+                        power: 1,
+                        sat: 'ASH',
+                        feed: '0',
+                        active: false
+                    };
+                    Patch('equipment', tmpAntenna);
+                });
+            });
+    });
+
+    socket.on('ACTIVATE', (server) => {
+        // Delete instructor signals from satEnv
+        knex('satenv')
+            .select('*')
+            .where('server', server)
+            .andWhere('team', 'Instructor')
+            .then(res => {
+                res.forEach(signal => {
+                    Delete('satEnv', signal)}
+                );
+            })
+            .then(() => {
+                // Post all signals to satEnv
+                knex('equipment')
+                    .select('*')
+                    .where('server', server)
+                    .where('team', 'Instructor')
+                    .then(res => {
+                        res.forEach(signal => {
+                            const tmpSignal = {
+                                ...signal,
+                                active: true
+                            };
+                            const tmpEnvSignal = {
+                                id: signal.id,
+                                server: signal.server,
+                                conn: signal.conn,
+                                team: signal.team,
+                                cf: Number(signal.cf),
+                                dr: Number(signal.dr),
+                                fec: Number(signal.fec),
+                                mod: Number(signal.mod),
+                                power: signal.power,
+                                band: signal.sat === 'ASH' ? 'C' : signal.sat === 'DRSC' ? 'Ku' : 'Ka',
+                                sat: signal.sat,
+                                feed: signal.feed,
+                                stage: "ULIF",
+                                active: true
+                            };
+                            Patch('equipment', tmpSignal);
+                            Post('satEnv', tmpEnvSignal);
+                        });
+                    })
+            });
+    });
+
+    socket.on('DEACTIVATE', (server) => {
+        // Delete instructor signals from satEnv
+        knex('satenv')
+            .select('*')
+            .where('server', server)
+            .andWhere('team', 'Instructor')
+            .then(res => {
+                res.forEach(signal => {
+                    Delete('satEnv', signal)
+                });
+            })
+            .then(() => {
+                // Post all signals to satEnv
+                knex('equipment')
+                    .select('*')
+                    .where('server', server)
+                    .where('team', 'Instructor')
+                    .then(res => {
+                        res.forEach(signal => {
+                            const tmpSignal = {
+                                ...signal,
+                                active: false
+                            };
+                            Patch('equipment', tmpSignal);
+                        });
+                    })
+            });
     });
 });
 

--- a/api/app.tsx
+++ b/api/app.tsx
@@ -4,8 +4,7 @@
    ADDRESS ON LINE 7
 */
 
-
-const ipAddress = [ '10.11.121.140', '192.168.1.82', '10.11.87.119'];
+const ipAddress = [ '192.168.0.53', '192.168.1.82', '10.11.87.119'];
 
 var express = require("express");
 const app = express();

--- a/api/app.tsx
+++ b/api/app.tsx
@@ -120,7 +120,7 @@ io.on('connection', (socket) => {
 
     socket.on('ScenarioClock', (props) => {
         console.log(props.message);
-        socket.emit('ScenarioClockAPI',props);
+        io.sockets.emit('ScenarioClockAPI',props);
         console.log("API: Emitted the message back out.")
     })
 

--- a/api/app.tsx
+++ b/api/app.tsx
@@ -118,6 +118,12 @@ io.on('connection', (socket) => {
         };
     };
 
+    socket.on('ScenarioClock', (props) => {
+        console.log(props.message);
+        socket.emit('ScenarioClockAPI',props);
+        console.log("API: Emitted the message back out.")
+    })
+
     socket.on('JOIN', (server, team) => {
         socket.join(server)
         socket.join(`${server}_${team}`)

--- a/ui/src/components/Chat/Chat.tsx
+++ b/ui/src/components/Chat/Chat.tsx
@@ -9,6 +9,7 @@ const Chat = () => {
     const [chatVisible, setChatVisible] = useState<boolean>(false);
 
     const handleChatUpdate = (update: any) => {
+        if ( update.server !== ewok.server ) return;
         const tmpMessages = {...messages};
         tmpMessages.messages.push(update.message);
         tmpMessages.currentMessage = '';

--- a/ui/src/components/Instructor/SignalDetails.tsx
+++ b/ui/src/components/Instructor/SignalDetails.tsx
@@ -308,7 +308,6 @@ const SignalDetails = () => {
                 };
                 socket.emit('POST', 'satEnv', tmpGroupSignal);
                 setVisibleSignal(true)
-                console.log(groupSignal)
                 socket.emit('PATCH', 'equipment', {...groupSignal, active: true});
             }
         };
@@ -327,8 +326,20 @@ const SignalDetails = () => {
                     :<TbEyeOff color={!visibleSignal ? 'red' : 'white'} id={groupSignal.id.toString()} onClick={()=> handleClickSignalEyeball()}/>}
             </React.Fragment>
         )
-    }
+    };
     
+    const handleClickReset = () => {
+        socket.emit('RESET', ewok.server);
+    };
+
+    const handleClickActivate = () => {
+        socket.emit('ACTIVATE', ewok.server);
+    };
+
+    const handleClickDeactivate = () => {
+        socket.emit('DEACTIVATE', ewok.server);
+    };
+
     return(
         <>
             <div className="sidebar">
@@ -354,6 +365,9 @@ const SignalDetails = () => {
                 })}
                 <button onClick={() => handleClickSaveScenario()}>Save Scenario</button>
                 <button onClick={() => handleClickLoadScenario()}>Load Scenario</button>
+                <button onClick = {() => handleClickReset()}>RESET STUDENT EQUIPMENT</button>
+                <button onClick = {() => handleClickActivate()}>ACTIVATE ALL</button>
+                <button onClick = {() => handleClickDeactivate()}>DEACTIVATE ALL</button>
             </div>
             <div className="signalDetails">
                 <div>

--- a/ui/src/components/Page/ClockModule/LocalClock.tsx
+++ b/ui/src/components/Page/ClockModule/LocalClock.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useState } from 'react';
+
+const LocalClock = () => {
+    let time = new Date().toLocaleTimeString();
+    const [currentTime, setCurrentTime] = useState(time);
+
+    const updateTime = () => {
+        let time = new Date().toLocaleTimeString();
+        setCurrentTime(time);
+    }
+
+    setInterval(updateTime, 1000/*ms*/);
+    
+    return (
+        <div>
+            Local: {currentTime}
+        </div>    
+    )
+
+}
+
+export default LocalClock

--- a/ui/src/components/Page/ClockModule/ScenarioClock.css
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.css
@@ -1,0 +1,53 @@
+.ScenarioClock {
+    display:inline-flex;
+    flex-wrap:nowrap;
+    font-size:22px;
+    justify-content: center;
+
+}
+
+.ScenarioClockButtons {
+    display: inline-flex;
+    font-size: 20px;
+    padding-left: 0px;
+    padding-right: 0px;
+}
+
+.ScenarioClockButtonSet {
+    padding-right: 0px;
+}
+.ScenarioClockButtonStartStop {
+    padding-left: 0px;
+}
+.ScenarioClockButtons * {
+    padding-left: 16px;
+    padding-right: 16px;
+}
+
+
+.ScenarioClockTime {
+    display:flex;
+    font-size: 22px;
+    padding-top: 12px;
+    padding-left: 10px;
+    padding-right: 10px;
+
+}
+
+.timeInput {
+    padding-left: 5px;
+    padding-right: 5px;
+    display: inline-flex;
+    font-size: 20px;
+}
+
+.TIBox {
+    display: inline-flex;
+    padding-right: 12px;
+    padding-top: 0.5em;
+}
+.TIBox * {
+    width: 40px;
+    height: 28px;
+    font-size: 20px;
+}

--- a/ui/src/components/Page/ClockModule/ScenarioClock.css
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.css
@@ -51,3 +51,7 @@
     height: 28px;
     font-size: 20px;
 }
+.BadTimeInput {
+    color: red;
+    caret-color: white;
+}

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -5,28 +5,45 @@ import { useEwokContext } from "../../../context/EwokContext";
 const ScenarioClock = () => {
 
     const {socket, ewok} = useEwokContext();
+    const [isRunning, setIsRunning] = useState<boolean>(false);
 
     // This is just to show the EWOK context current details at each page for debug purposes
     console.log("Server: "+ewok.server)
     console.log("BaseURL: "+ewok.baseURL)
     console.log("Team: "+ewok.team)
 
+    // Structure of update and prop is 
+    //{
+    //    
+    //    TYPE: StartStop or ClockSet (dT calc'd locally)
+    //    If StartStop, then will have isRunning var, true if start, false if stop
+    //    If ClockSet, then will have time to set it to, then will have time
+    //    IR: true or false for is running or not
+    //    ClockSet: true or false for whether or not clock is being set
+    //    StartStop: string of "start" or "stop" to denote what to do
+    //    dT: number or something for amount to adjust zulu time by
+    //}
+
     // Handlers
     const handleClockUpdate = (update: any) => {
-        alert("The string was "+update.message);
-        console.log(update); 
+        // alert("The string was "+update.message);
+        // console.log(update); 
+        if (update.type === "StartStop") {alert('StartStop type object returned.')}
+        else if (update.type === "ClockSet") {alert('ClockSet type object returned.')}
+        else {alert('Neither type detected.')}
+
     };
     const handleSetButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{message:"\"Clock Set Clicked\""});
+        socket.emit('ScenarioClock',{type:"ClockSet"});
     }
     const handleStartButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{message:"\"Clock Start Clicked\""});
+        socket.emit('ScenarioClock',{type:"StartStop"});
     }
     const handleStopButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{message:"\"Clock Stop Clicked\""});
+        socket.emit('ScenarioClock',{type:"StartStop"});
     }
 
     // Handle Clock Status Update
@@ -39,10 +56,13 @@ const ScenarioClock = () => {
 
 
     return (
-        <div className="ScenarioClockButtons">
-            <div className="ScenarioClockButtonSet"><button onClick={handleSetButton}>Set</button></div>
-            <div className="ScenarioClockButtonStart"><button onClick={handleStartButton}>Start</button></div>
-            <div className="ScenarioClockButtonStop"><button onClick={handleStopButton}>Stop</button></div>
+        <div>
+            <div className="ScenarioClockText">Time</div>
+            <div className="ScenarioClockButtons">
+                <div className="ScenarioClockButtonSet"><button onClick={handleSetButton}>Set</button></div>
+                <div className="ScenarioClockButtonStart"><button onClick={handleStartButton}>Start</button></div>
+                <div className="ScenarioClockButtonStop"><button onClick={handleStopButton}>Stop</button></div>
+            </div>
         </div>
     )
 }

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -28,7 +28,11 @@ const ScenarioClock = () => {
     const handleClockUpdate = (update: any) => {
         // alert("The string was "+update.message);
         // console.log(update); 
-        if (update.type === "StartStop") {alert('StartStop type object returned.')}
+        if (update.type === "StartStop") {
+            //alert('StartStop type object returned.');
+            if (update.runningBool) {setIsRunning(true)}
+            else if (!update.runningBool) {setIsRunning(false)}
+        }
         else if (update.type === "ClockSet") {alert('ClockSet type object returned.')}
         else {alert('Neither type detected.')}
 
@@ -39,11 +43,11 @@ const ScenarioClock = () => {
     }
     const handleStartButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{type:"StartStop"});
+        socket.emit('ScenarioClock',{type:"StartStop",runningBool:true});
     }
     const handleStopButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{type:"StartStop"});
+        socket.emit('ScenarioClock',{type:"StartStop",runningBool:false});
     }
 
     // Handle Clock Status Update
@@ -54,17 +58,25 @@ const ScenarioClock = () => {
         } // This was returning the alert case twice, so adding socket.off as seen solved the problem
     }, [socket]);
 
-
-    return (
-        <div>
-            <div className="ScenarioClockText">Time</div>
-            <div className="ScenarioClockButtons">
-                <div className="ScenarioClockButtonSet"><button onClick={handleSetButton}>Set</button></div>
-                <div className="ScenarioClockButtonStart"><button onClick={handleStartButton}>Start</button></div>
-                <div className="ScenarioClockButtonStop"><button onClick={handleStopButton}>Stop</button></div>
+    if (ewok.team === "Instructor") {
+        return (
+            <div>
+                <div className="ScenarioClockText">Running: {isRunning.toString()}</div>
+                <div className="ScenarioClockButtons">
+                    <div className="ScenarioClockButtonSet"><button onClick={handleSetButton}>Set</button></div>
+                    <div className="ScenarioClockButtonStart"><button onClick={handleStartButton}>Start</button></div>
+                    <div className="ScenarioClockButtonStop"><button onClick={handleStopButton}>Stop</button></div>
+                </div>
             </div>
-        </div>
-    )
+        )
+    }
+    else {
+        return (
+            <div>
+                <div className="ScenarioClockText">Running: {isRunning.toString()}</div>
+            </div>
+        )
+    }
 }
 
 export default ScenarioClock;

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -9,6 +9,7 @@ import '../Header.css';
 
 const ScenarioClock = () => {
     let time = new Date().toUTCString();
+    let intervalID:any;
 
     const {socket, ewok} = useEwokContext();
     const [isRunning, setIsRunning] = useState<boolean>(false);
@@ -19,31 +20,13 @@ const ScenarioClock = () => {
     console.log("BaseURL: "+ewok.baseURL)
     console.log("Team: "+ewok.team)
 
-    // Structure of update and prop is 
-    //{
-    //    
-    //    TYPE: StartStop or ClockSet (dT calc'd locally)
-    //    If StartStop, then will have isRunning var, true if start, false if stop
-    //    If ClockSet, then will have time to set it to, then will have time
-    //}
-
     // Handlers
     const handleClockUpdate = (update: any) => {
-        // alert("The string was "+update.message);
-        // console.log(update); 
-        if (update.type === "StartStop") {
-            setIsRunning(update.runningBool);
-            alert('Setting isRunning to '+update.runningBool.toString())
-        }
+        if (update.type === "StartStop") {setIsRunning(update.runningBool);}
         else if (update.type === "ClockSet") {alert('ClockSet type object returned.')}
         else {alert('Neither type detected.')}
-
     };
-    const updateTime = () => {
-        let time = new Date().toUTCString();
-        setScenarioTime(time);
-    };
-    const handleSetButton = (e:any) => {
+    const handleEditButton = (e:any) => {
         e.preventDefault();
         socket.emit('ScenarioClock',{type:"ClockSet"});
     }
@@ -51,10 +34,6 @@ const ScenarioClock = () => {
         e.preventDefault();
         socket.emit('ScenarioClock',{type:"StartStop",runningBool:!isRunning});
     }
-    // const handleStopButton = (e:any) => {
-    //     e.preventDefault();
-    //     socket.emit('ScenarioClock',{type:"StartStop",runningBool:false});
-    // }
 
     // Handle Clock Status Update
     useEffect(() => {
@@ -65,14 +44,13 @@ const ScenarioClock = () => {
     }, [socket]);
 
     // Handle Clock Display increments
+    const updateTime = () => {
+        let time = new Date().toUTCString();
+        setScenarioTime(time);
+    };
     useEffect(()=> {
-        let inte:any;
-        if (isRunning) {
-            inte = setInterval(updateTime, 1000/*ms*/);
-        }
-        else if (!isRunning) {
-            return clearInterval(inte);
-        }
+        if (isRunning) {intervalID = setInterval(updateTime, 1000/*ms*/);}
+        return () => clearInterval(intervalID);
     },[isRunning])
 
     if (ewok.team === "Instructor") {
@@ -80,7 +58,7 @@ const ScenarioClock = () => {
             <div className="ScenarioClock">
                 <div className="ScenarioClockTime">Scenario Time: {scenarioTime.substring(17,25)} {isRunning.toString()}</div>
                 <div className="ScenarioClockButtons">
-                    <div className="ScenarioClockButtonSet"><button onClick={handleSetButton}>Set</button></div>
+                    <div className="ScenarioClockButtonSet"><button onClick={handleEditButton}>Set</button></div>
                     <div className="ScenarioClockButtonStartStop"><button onClick={handleStartStopButton}>{ isRunning ? 'Stop' : 'Start' }</button></div>
                 </div>
             </div>

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -75,11 +75,12 @@ const ScenarioClock = () => {
         // Hides Edit display, gives error message if clock is running, and
         // sends new scenario time to other users
 
-        setEditTimeShow(false);
+        
         if (isRunning) {
             alert('You must have the scenario clock stopped in order to change the scenario time.');
             return;
         }
+        setEditTimeShow(false);
         socket.emit('ScenarioClock',{type:"ClockSet",emitTimeSet:tmpScenTime});
     }
 

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -15,8 +15,11 @@ const ScenarioClock = () => {
     const [isRunning, setIsRunning] = useState<boolean>(false);
     const [scenarioTime, setScenarioTime] = useState(time);
     const [editTimeShow, setEditTimeShow] = useState<boolean>(false);
-    const [tmpScenTime, setTmpScenTime] = useState({HH:0,mm:0,ss:0});
+    const [tmpScenTime, setTmpScenTime] = useState({HH:0,MM:0,SS:0});
     const [deltaT, setDeltaT] = useState(0);
+    const [hhInputBad, setHHInputBad] = useState<boolean>(false);
+    const [mmInputBad, setMMInputBad] = useState<boolean>(false);
+    const [ssInputBad, setSSInputBad] = useState<boolean>(false);
 
     // This is just to show the EWOK context current details at each page for debug purposes
     console.log("Server: "+ewok.server)
@@ -28,9 +31,9 @@ const ScenarioClock = () => {
         return (
             <div className="timeInput">
                 <div className="TIBox">
-                    <input placeholder="HH"></input>:
-                    <input placeholder="MM"></input>:
-                    <input placeholder="SS"></input>
+                    <input type="text" placeholder="HH" onInput={e => handleHHChange(e)} className={hhInputBad ? "BadTimeInput" : ""}></input>:
+                    <input type="text" placeholder="MM" onChange={e => handleMMChange(e)} className={mmInputBad ? "BadTimeInput" : ""}></input>:
+                    <input type="text" placeholder="SS" onChange={e => handleSSChange(e)} className={ssInputBad ? "BadTimeInput" : ""}></input>
                 </div>
                 <div className="SetButton">
                     <button onClick={handleSetButton}>Set</button>
@@ -68,32 +71,35 @@ const ScenarioClock = () => {
                     HH: input
                 }
                 setTmpScenTime(tmpClock);
-            }
-        }     
+                setHHInputBad(false);
+            } else {setHHInputBad(true)}
+        } else {setHHInputBad(true)}  
     }
-    const handlemmChange = (e:any) => {
+    const handleMMChange = (e:any) => {
         let input = parseInt(e.target.value);
         if (!isNaN(input)) {
             if (input >= 0 && input < 60) {
                 const tmpClock = {
                     ...tmpScenTime,
-                    mm: input
+                    MM: input
                 }
                 setTmpScenTime(tmpClock);
-            }
-        }     
+                setMMInputBad(false);
+            } else {setMMInputBad(true)}
+        } else {setMMInputBad(true)} 
     }
-    const handlessChange = (e:any) => {
+    const handleSSChange = (e:any) => {
         let input = parseInt(e.target.value);
         if (!isNaN(input)) {
             if (input >= 0 && input < 60) {
                 const tmpClock = {
                     ...tmpScenTime,
-                    ss: input
+                    SS: input
                 }
                 setTmpScenTime(tmpClock);
-            }
-        }     
+                setSSInputBad(false);
+            } else {setSSInputBad(true)}
+        } else {setSSInputBad(true)}
     }
 
     // Handle Clock Status Update
@@ -114,15 +120,16 @@ const ScenarioClock = () => {
         return () => clearInterval(intervalID);
     },[isRunning])
 
+    // /Scenario Time: {scenarioTime.substring(17,25)}
     if (ewok.team === "Instructor") {
         return (
             <div className="ScenarioClock">
-                <div className="ScenarioClockTime">Scenario Time: {scenarioTime.substring(17,25)}</div>
+                <div className="ScenarioClockTime">{JSON.stringify(tmpScenTime)}</div>
                 <div className="ScenarioClockButtons">
                     <div className="ScenarioClockButtonSet"><button onClick={handleEditButton}>Edit</button></div>
                     <div className="ScenarioClockButtonStartStop"><button onClick={handleStartStopButton}>{ isRunning ? 'Stop' : 'Start' }</button></div>
                 </div>
-                {editTimeShow ? <TimeSetForm /> : null}
+                {editTimeShow ? TimeSetForm() : null}
             </div>
         )
     }

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -15,6 +15,8 @@ const ScenarioClock = () => {
     const [isRunning, setIsRunning] = useState<boolean>(false);
     const [scenarioTime, setScenarioTime] = useState(time);
     const [editTimeShow, setEditTimeShow] = useState<boolean>(false);
+    const [tmpScenTime, setTmpScenTime] = useState({HH:0,mm:0,ss:0});
+    const [deltaT, setDeltaT] = useState(0);
 
     // This is just to show the EWOK context current details at each page for debug purposes
     console.log("Server: "+ewok.server)
@@ -54,6 +56,44 @@ const ScenarioClock = () => {
     const handleStartStopButton = (e:any) => {
         e.preventDefault();
         socket.emit('ScenarioClock',{type:"StartStop",runningBool:!isRunning});
+    }
+
+    // Handle time inputs
+    const handleHHChange = (e:any) => {
+        let input = parseInt(e.target.value);
+        if (!isNaN(input)) {
+            if (input >= 0 && input < 24) {
+                const tmpClock = {
+                    ...tmpScenTime,
+                    HH: input
+                }
+                setTmpScenTime(tmpClock);
+            }
+        }     
+    }
+    const handlemmChange = (e:any) => {
+        let input = parseInt(e.target.value);
+        if (!isNaN(input)) {
+            if (input >= 0 && input < 60) {
+                const tmpClock = {
+                    ...tmpScenTime,
+                    mm: input
+                }
+                setTmpScenTime(tmpClock);
+            }
+        }     
+    }
+    const handlessChange = (e:any) => {
+        let input = parseInt(e.target.value);
+        if (!isNaN(input)) {
+            if (input >= 0 && input < 60) {
+                const tmpClock = {
+                    ...tmpScenTime,
+                    ss: input
+                }
+                setTmpScenTime(tmpClock);
+            }
+        }     
     }
 
     // Handle Clock Status Update

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { useState, useEffect } from 'react';
+import { useEwokContext } from "../../../context/EwokContext";
+
+const ScenarioClock = () => {
+
+    const {socket, ewok} = useEwokContext();
+
+    // This is just to show the EWOK context current details at each page for debug purposes
+    console.log("Server: "+ewok.server)
+    console.log("BaseURL: "+ewok.baseURL)
+    console.log("Team: "+ewok.team)
+
+    // Handlers
+    const handleClockUpdate = (update: any) => {
+        alert('Ping went through Scenario Clock Socket' + '\nThe string was '+update.message);  
+        console.log(update); 
+
+    };
+
+    const handleClockButton = (e:any) => {
+        e.preventDefault();
+        socket.emit('ScenarioClock',{message:"Clock Test"});
+    }
+
+    // Handle Clock Status Update
+    useEffect(() => {
+        socket.on('ScenarioClockAPI', handleClockUpdate);
+        
+    }, [socket]);
+
+
+    return (
+        <div><button onClick={handleClockButton}>Test</button></div>
+    )
+}
+
+export default ScenarioClock;

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -1,19 +1,19 @@
 import React from "react";
 import { useState, useEffect } from 'react';
 import { useEwokContext } from "../../../context/EwokContext";
-import '../Header.css';
+import './ScenarioClock.css';
 
 // TODO: Find a way to get around the async nature of use State such that the correct boolean will emit on start/stop
 
 
 
 const ScenarioClock = () => {
-    //let time = new Date().toUTCString();
+    let time = new Date().toUTCString();
     let intervalID:any;
 
     const {socket, ewok} = useEwokContext();
     const [isRunning, setIsRunning] = useState<boolean>(false);
-    const [scenarioTime, setScenarioTime] = useState<number>(0);
+    const [scenarioTime, setScenarioTime] = useState(time);
     const [editTimeShow, setEditTimeShow] = useState<boolean>(false);
 
     // This is just to show the EWOK context current details at each page for debug purposes
@@ -24,8 +24,8 @@ const ScenarioClock = () => {
     // Edit Popup Form
     const TimeSetForm = () => {
         return (
-            <div>
-                <div className="timeInput">
+            <div className="timeInput">
+                <div className="TIBox">
                     <input placeholder="HH"></input>:
                     <input placeholder="MM"></input>:
                     <input placeholder="SS"></input>
@@ -39,7 +39,7 @@ const ScenarioClock = () => {
 
     // Handlers
     const handleClockUpdate = (update: any) => {
-        if (update.type === "StartStop") {setIsRunning(update.runningBool);setScenarioTime(update.timeKey)}
+        if (update.type === "StartStop") {setIsRunning(update.runningBool)}
         else if (update.type === "ClockSet") {alert('ClockSet type object returned.')}
         else {alert('Neither type detected.')}
     };
@@ -53,7 +53,7 @@ const ScenarioClock = () => {
     }
     const handleStartStopButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{type:"StartStop",runningBool:!isRunning,timeKey:scenarioTime});
+        socket.emit('ScenarioClock',{type:"StartStop",runningBool:!isRunning});
     }
 
     // Handle Clock Status Update
@@ -66,8 +66,8 @@ const ScenarioClock = () => {
 
     // Handle Clock Display increments
     const updateTime = () => {
-        //let time = new Date().toUTCString();
-        setScenarioTime(scenarioTime === 86399 ? 0 : scenarioTime => scenarioTime+1);
+        let time = new Date().toUTCString();
+        setScenarioTime(time);
     };
     useEffect(()=> {
         if (isRunning) {intervalID = setInterval(updateTime, 1000/*ms*/);}
@@ -77,19 +77,19 @@ const ScenarioClock = () => {
     if (ewok.team === "Instructor") {
         return (
             <div className="ScenarioClock">
-                <div className="ScenarioClockTime">Scenario Time: {scenarioTime.toString()} {isRunning.toString()}</div>
+                <div className="ScenarioClockTime">Scenario Time: {scenarioTime.substring(17,25)}</div>
                 <div className="ScenarioClockButtons">
-                    <div className="ScenarioClockButtonSet"><button onClick={handleEditButton}>Edit</button>{editTimeShow.toString()}</div>
+                    <div className="ScenarioClockButtonSet"><button onClick={handleEditButton}>Edit</button></div>
                     <div className="ScenarioClockButtonStartStop"><button onClick={handleStartStopButton}>{ isRunning ? 'Stop' : 'Start' }</button></div>
                 </div>
-                <div className="timeInput">{editTimeShow ? <TimeSetForm /> : null}</div>
+                {editTimeShow ? <TimeSetForm /> : null}
             </div>
         )
     }
-    //scenarioTime.substring(17,25)
+    
     else {
         return (
-            <div className="ScenarioClockTime">Scenario Time: {scenarioTime.toString()} {isRunning.toString()}</div>
+            <div className="ScenarioClock">Scenario Time: {scenarioTime.substring(17,25)}</div>
             
         )
     }

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -46,6 +46,7 @@ const ScenarioClock = () => {
         time.setMinutes(time.getMinutes()-deltaT.MM);
         time.setSeconds(time.getSeconds()-deltaT.SS);
         setScenarioTime(time);
+        setTmpScenTime({HH:time.getHours(), MM:time.getMinutes(), SS: time.getSeconds()})
     };
 
     const handleEditButton = (e:any) => {
@@ -69,6 +70,7 @@ const ScenarioClock = () => {
             tmpDelT = {HH: tmpHH - tmpScenTime.HH, MM: tmpMM - tmpScenTime.MM, SS: tmpSS - tmpScenTime.SS}
         }
         socket.emit('ScenarioClock',{type:"StartStop", runningBool:!isRunning, timeDeltaT: tmpDelT});
+        console.log('Generated new DelT'+JSON.stringify(tmpDelT))
     }
 
     const handleSetButton = () => {

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -177,7 +177,7 @@ const ScenarioClock = () => {
     if (ewok.team === "Instructor") {
         return (
             <div className="ScenarioClock">
-                <div className="ScenarioClockTime">Scenario Time: {scenarioTime.toString().substring(16,25)}</div>
+                <div className="ScenarioClockTime">Scenario: {scenarioTime.toString().substring(16,25)}</div>
                 <div className="ScenarioClockButtons">
                     <div className="ScenarioClockButtonSet"><button onClick={handleEditButton}>Edit</button></div>
                     <div className="ScenarioClockButtonStartStop"><button onClick={handleStartStopButton}>{ isRunning ? 'Stop' : 'Start' }</button></div>
@@ -190,7 +190,7 @@ const ScenarioClock = () => {
     // Show only the scenario time for anyone not logged in as the instructor
     else {
         return (
-            <div className="ScenarioClock">Scenario Time: {scenarioTime.toString().substring(16,25)}</div>
+            <div className="ScenarioClock">Scenario: {scenarioTime.toString().substring(16,25)}</div>
         )
     }
 }

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -8,31 +8,52 @@ import '../Header.css';
 
 
 const ScenarioClock = () => {
-    let time = new Date().toUTCString();
+    //let time = new Date().toUTCString();
     let intervalID:any;
 
     const {socket, ewok} = useEwokContext();
     const [isRunning, setIsRunning] = useState<boolean>(false);
-    const [scenarioTime, setScenarioTime] = useState<string>(time);
+    const [scenarioTime, setScenarioTime] = useState<number>(0);
+    const [editTimeShow, setEditTimeShow] = useState<boolean>(false);
 
     // This is just to show the EWOK context current details at each page for debug purposes
     console.log("Server: "+ewok.server)
     console.log("BaseURL: "+ewok.baseURL)
     console.log("Team: "+ewok.team)
 
+    // Edit Popup Form
+    const TimeSetForm = () => {
+        return (
+            <div>
+                <div className="timeInput">
+                    <input placeholder="HH"></input>:
+                    <input placeholder="MM"></input>:
+                    <input placeholder="SS"></input>
+                </div>
+                <div className="SetButton">
+                    <button onClick={handleSetButton}>Set</button>
+                </div>
+            </div>
+        );
+    }
+
     // Handlers
     const handleClockUpdate = (update: any) => {
-        if (update.type === "StartStop") {setIsRunning(update.runningBool);}
+        if (update.type === "StartStop") {setIsRunning(update.runningBool);setScenarioTime(update.timeKey)}
         else if (update.type === "ClockSet") {alert('ClockSet type object returned.')}
         else {alert('Neither type detected.')}
     };
     const handleEditButton = (e:any) => {
         e.preventDefault();
+        setEditTimeShow(!editTimeShow)
+    }
+    const handleSetButton = () => {
+        setEditTimeShow(false);
         socket.emit('ScenarioClock',{type:"ClockSet"});
     }
     const handleStartStopButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{type:"StartStop",runningBool:!isRunning});
+        socket.emit('ScenarioClock',{type:"StartStop",runningBool:!isRunning,timeKey:scenarioTime});
     }
 
     // Handle Clock Status Update
@@ -45,8 +66,8 @@ const ScenarioClock = () => {
 
     // Handle Clock Display increments
     const updateTime = () => {
-        let time = new Date().toUTCString();
-        setScenarioTime(time);
+        //let time = new Date().toUTCString();
+        setScenarioTime(scenarioTime === 86399 ? 0 : scenarioTime => scenarioTime+1);
     };
     useEffect(()=> {
         if (isRunning) {intervalID = setInterval(updateTime, 1000/*ms*/);}
@@ -56,17 +77,19 @@ const ScenarioClock = () => {
     if (ewok.team === "Instructor") {
         return (
             <div className="ScenarioClock">
-                <div className="ScenarioClockTime">Scenario Time: {scenarioTime.substring(17,25)} {isRunning.toString()}</div>
+                <div className="ScenarioClockTime">Scenario Time: {scenarioTime.toString()} {isRunning.toString()}</div>
                 <div className="ScenarioClockButtons">
-                    <div className="ScenarioClockButtonSet"><button onClick={handleEditButton}>Set</button></div>
+                    <div className="ScenarioClockButtonSet"><button onClick={handleEditButton}>Edit</button>{editTimeShow.toString()}</div>
                     <div className="ScenarioClockButtonStartStop"><button onClick={handleStartStopButton}>{ isRunning ? 'Stop' : 'Start' }</button></div>
                 </div>
+                <div className="timeInput">{editTimeShow ? <TimeSetForm /> : null}</div>
             </div>
         )
     }
+    //scenarioTime.substring(17,25)
     else {
         return (
-            <div className="ScenarioClockTime">Scenario Time: {scenarioTime.substring(17,25)} {isRunning.toString()}</div>
+            <div className="ScenarioClockTime">Scenario Time: {scenarioTime.toString()} {isRunning.toString()}</div>
             
         )
     }

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -1,11 +1,18 @@
 import React from "react";
 import { useState, useEffect } from 'react';
 import { useEwokContext } from "../../../context/EwokContext";
+import '../Header.css';
+
+// TODO: Find a way to get around the async nature of use State such that the correct boolean will emit on start/stop
+
+
 
 const ScenarioClock = () => {
+    let time = new Date().toUTCString();
 
     const {socket, ewok} = useEwokContext();
     const [isRunning, setIsRunning] = useState<boolean>(false);
+    const [scenarioTime, setScenarioTime] = useState<string>(time);
 
     // This is just to show the EWOK context current details at each page for debug purposes
     console.log("Server: "+ewok.server)
@@ -18,10 +25,6 @@ const ScenarioClock = () => {
     //    TYPE: StartStop or ClockSet (dT calc'd locally)
     //    If StartStop, then will have isRunning var, true if start, false if stop
     //    If ClockSet, then will have time to set it to, then will have time
-    //    IR: true or false for is running or not
-    //    ClockSet: true or false for whether or not clock is being set
-    //    StartStop: string of "start" or "stop" to denote what to do
-    //    dT: number or something for amount to adjust zulu time by
     //}
 
     // Handlers
@@ -29,26 +32,29 @@ const ScenarioClock = () => {
         // alert("The string was "+update.message);
         // console.log(update); 
         if (update.type === "StartStop") {
-            //alert('StartStop type object returned.');
-            if (update.runningBool) {setIsRunning(true)}
-            else if (!update.runningBool) {setIsRunning(false)}
+            setIsRunning(update.runningBool);
+            alert('Setting isRunning to '+update.runningBool.toString())
         }
         else if (update.type === "ClockSet") {alert('ClockSet type object returned.')}
         else {alert('Neither type detected.')}
 
     };
+    const updateTime = () => {
+        let time = new Date().toUTCString();
+        setScenarioTime(time);
+    };
     const handleSetButton = (e:any) => {
         e.preventDefault();
         socket.emit('ScenarioClock',{type:"ClockSet"});
     }
-    const handleStartButton = (e:any) => {
+    const handleStartStopButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{type:"StartStop",runningBool:true});
+        socket.emit('ScenarioClock',{type:"StartStop",runningBool:!isRunning});
     }
-    const handleStopButton = (e:any) => {
-        e.preventDefault();
-        socket.emit('ScenarioClock',{type:"StartStop",runningBool:false});
-    }
+    // const handleStopButton = (e:any) => {
+    //     e.preventDefault();
+    //     socket.emit('ScenarioClock',{type:"StartStop",runningBool:false});
+    // }
 
     // Handle Clock Status Update
     useEffect(() => {
@@ -58,23 +64,32 @@ const ScenarioClock = () => {
         } // This was returning the alert case twice, so adding socket.off as seen solved the problem
     }, [socket]);
 
+    // Handle Clock Display increments
+    useEffect(()=> {
+        let inte:any;
+        if (isRunning) {
+            inte = setInterval(updateTime, 1000/*ms*/);
+        }
+        else if (!isRunning) {
+            return clearInterval(inte);
+        }
+    },[isRunning])
+
     if (ewok.team === "Instructor") {
         return (
-            <div>
-                <div className="ScenarioClockText">Running: {isRunning.toString()}</div>
+            <div className="ScenarioClock">
+                <div className="ScenarioClockTime">Scenario Time: {scenarioTime.substring(17,25)} {isRunning.toString()}</div>
                 <div className="ScenarioClockButtons">
                     <div className="ScenarioClockButtonSet"><button onClick={handleSetButton}>Set</button></div>
-                    <div className="ScenarioClockButtonStart"><button onClick={handleStartButton}>Start</button></div>
-                    <div className="ScenarioClockButtonStop"><button onClick={handleStopButton}>Stop</button></div>
+                    <div className="ScenarioClockButtonStartStop"><button onClick={handleStartStopButton}>{ isRunning ? 'Stop' : 'Start' }</button></div>
                 </div>
             </div>
         )
     }
     else {
         return (
-            <div>
-                <div className="ScenarioClockText">Running: {isRunning.toString()}</div>
-            </div>
+            <div className="ScenarioClockTime">Scenario Time: {scenarioTime.substring(17,25)} {isRunning.toString()}</div>
+            
         )
     }
 }

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -13,20 +13,21 @@ const ScenarioClock = () => {
 
     // Handlers
     const handleClockUpdate = (update: any) => {
-        alert('Ping went through Scenario Clock Socket' + '\nThe string was '+update.message);  
+        alert("The string was "+update.message);
         console.log(update); 
-
     };
 
     const handleClockButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{message:"Clock Test"});
+        socket.emit('ScenarioClock',{message:"\"How many times will it show?\""});
     }
 
     // Handle Clock Status Update
     useEffect(() => {
         socket.on('ScenarioClockAPI', handleClockUpdate);
-        
+        return () => {
+            socket.off('ScenarioClockAPI').off();
+        } // This was returning the alert case twice, so adding socket.off as seen solved the problem
     }, [socket]);
 
 

--- a/ui/src/components/Page/ClockModule/ScenarioClock.tsx
+++ b/ui/src/components/Page/ClockModule/ScenarioClock.tsx
@@ -16,10 +16,17 @@ const ScenarioClock = () => {
         alert("The string was "+update.message);
         console.log(update); 
     };
-
-    const handleClockButton = (e:any) => {
+    const handleSetButton = (e:any) => {
         e.preventDefault();
-        socket.emit('ScenarioClock',{message:"\"How many times will it show?\""});
+        socket.emit('ScenarioClock',{message:"\"Clock Set Clicked\""});
+    }
+    const handleStartButton = (e:any) => {
+        e.preventDefault();
+        socket.emit('ScenarioClock',{message:"\"Clock Start Clicked\""});
+    }
+    const handleStopButton = (e:any) => {
+        e.preventDefault();
+        socket.emit('ScenarioClock',{message:"\"Clock Stop Clicked\""});
     }
 
     // Handle Clock Status Update
@@ -32,7 +39,11 @@ const ScenarioClock = () => {
 
 
     return (
-        <div><button onClick={handleClockButton}>Test</button></div>
+        <div className="ScenarioClockButtons">
+            <div className="ScenarioClockButtonSet"><button onClick={handleSetButton}>Set</button></div>
+            <div className="ScenarioClockButtonStart"><button onClick={handleStartButton}>Start</button></div>
+            <div className="ScenarioClockButtonStop"><button onClick={handleStopButton}>Stop</button></div>
+        </div>
     )
 }
 

--- a/ui/src/components/Page/ClockModule/ZuluClock.tsx
+++ b/ui/src/components/Page/ClockModule/ZuluClock.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useState } from 'react';
+
+const ZuluClock = () => {
+    let time = new Date().toUTCString();
+    const [currentTime, setCurrentTime] = useState(time);
+
+    const updateTime = () => {
+        let time = new Date().toUTCString();
+        setCurrentTime(time);
+    }
+
+    setInterval(updateTime, 1000/*ms*/);
+    
+    return (
+        <div>
+            Zulu: {currentTime.substring(17,25)}
+        </div>    
+    )
+
+}
+
+export default ZuluClock;

--- a/ui/src/components/Page/Header.css
+++ b/ui/src/components/Page/Header.css
@@ -20,6 +20,19 @@
     font-size: 36px;
 }
 
+.ScenarioClockButtons {
+    display: grid;
+    grid-template-columns: repeat(3,1fr);
+}
+
+.ScenarioClockButtonStart, .ScenarioClockButtonStop, .ScenarioClockButtonSet {
+    font-size: 20px;
+    text-align: center;
+    border: none;
+    display: inline-block;
+}
+
+
 
 .ZuluClock {
     justify-content: center;
@@ -31,6 +44,7 @@
     align-content: center;
     font-size: 22px;
 }
+
 /* .ScenarioClock {
     justify-content: center;
     align-content: center;

--- a/ui/src/components/Page/Header.css
+++ b/ui/src/components/Page/Header.css
@@ -7,49 +7,63 @@
     background-color: #393e47;
     font-size: 30px;
     display:grid;
-    grid-template-columns: 1fr 3fr 3fr 3fr 1fr;
+    grid-template-columns: 1fr 3fr 3fr 5fr 1fr;
   }
   
-  .header * {
-    padding: 10px 20px 10px 20px;
-  }
-  
-
 
 .EWOK_Label {
-    font-size: 36px;
+    font-size: 28px;
+    padding: 10px 20px 10px 20px;
 }
+
 
 .ScenarioClockButtons {
-    display: grid;
-    grid-template-columns: repeat(3,1fr);
-}
-
-.ScenarioClockButtonStart, .ScenarioClockButtonStop, .ScenarioClockButtonSet {
+    display: flex;
+    flex-wrap: nowrap;
+    align-content: center;
     font-size: 20px;
     text-align: center;
-    border: none;
-    display: inline-block;
+    vertical-align: center;
+    padding: 10px 20px 10px 20px;
 }
 
-
-
-.ZuluClock {
-    justify-content: center;
-    align-content: center;
-    font-size: 22px;
+.ScenarioClockTime {
+    padding: 24px 0px 24px 0px;
 }
-.LocalClock {
-    justify-content: center;
-    align-content: center;
-    font-size: 22px;
+.ScenarioClockTimeNB {
+    padding: 0px 20px 10px 20px;
 }
 
 .ScenarioClock {
     justify-content: center;
     align-content: center;
     font-size: 22px;
+    display: flex;
+    flex-wrap: nowrap;
+    grid-template-columns: 4fr 1fr;
+    
+}
+
+.ScenarioClockNoButtons {
+    justify-content: center;
+    align-content: center;
+    font-size: 22px;
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: 1fr;
+    grid-template-columns: 1fr;
+    vertical-align: center;
+    padding: 24px 20px 10px 20px;
+}
+
+
+.ZuluClock {
+    justify-content: center;
+    align-content: center;
+    font-size: 22px;
+    padding: 10px 24px 10px 24px;
+}
+.LocalClock {
+    justify-content: center;
+    align-content: center;
+    font-size: 22px;
+    padding: 10px 24px 10px 24px;
 }

--- a/ui/src/components/Page/Header.css
+++ b/ui/src/components/Page/Header.css
@@ -1,0 +1,38 @@
+.header {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100%;
+    align-items: center;
+    background-color: #393e47;
+    font-size: 30px;
+    display:grid;
+    grid-template-columns: 1fr 3fr 3fr 3fr 1fr;
+  }
+  
+  .header * {
+    padding: 10px 20px 10px 20px;
+  }
+  
+
+
+.EWOK_Label {
+    font-size: 36px;
+}
+
+
+.ZuluClock {
+    justify-content: center;
+    align-content: center;
+    font-size: 22px;
+}
+.LocalClock {
+    justify-content: center;
+    align-content: center;
+    font-size: 22px;
+}
+/* .ScenarioClock {
+    justify-content: center;
+    align-content: center;
+    font-size: 22px;
+} */

--- a/ui/src/components/Page/Header.css
+++ b/ui/src/components/Page/Header.css
@@ -7,7 +7,7 @@
     background-color: #393e47;
     font-size: 30px;
     display:grid;
-    grid-template-columns: 1fr 3fr 3fr 5fr 1fr;
+    grid-template-columns: 1fr 3fr 3fr 3fr 1fr;
   }
   
 

--- a/ui/src/components/Page/Header.css
+++ b/ui/src/components/Page/Header.css
@@ -8,7 +8,7 @@
     background-color: #393e47;
     font-size: 30px;
     display:grid;
-    grid-template-columns: 1fr 3fr 3fr 5fr 1fr;
+    grid-template-columns: 1fr 3fr 3fr 3fr 1fr;
   }
   
 

--- a/ui/src/components/Page/Header.css
+++ b/ui/src/components/Page/Header.css
@@ -45,8 +45,11 @@
     font-size: 22px;
 }
 
-/* .ScenarioClock {
+.ScenarioClock {
     justify-content: center;
     align-content: center;
     font-size: 22px;
-} */
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr;
+}

--- a/ui/src/components/Page/Header.css
+++ b/ui/src/components/Page/Header.css
@@ -3,55 +3,18 @@
     left: 0;
     top: 0;
     width: 100%;
+    height: 70px;
     align-items: center;
     background-color: #393e47;
     font-size: 30px;
     display:grid;
-    grid-template-columns: 1fr 3fr 3fr 3fr 1fr;
+    grid-template-columns: 1fr 3fr 3fr 5fr 1fr;
   }
   
 
 .EWOK_Label {
-    font-size: 28px;
-    padding: 10px 20px 10px 20px;
-}
-
-
-.ScenarioClockButtons {
-    display: flex;
-    flex-wrap: nowrap;
-    align-content: center;
-    font-size: 20px;
-    text-align: center;
-    vertical-align: center;
-    padding: 10px 20px 10px 20px;
-}
-
-.ScenarioClockTime {
-    padding: 24px 0px 24px 0px;
-}
-.ScenarioClockTimeNB {
-    padding: 0px 20px 10px 20px;
-}
-
-.ScenarioClock {
-    justify-content: center;
-    align-content: center;
     font-size: 22px;
-    display: flex;
-    flex-wrap: nowrap;
-    grid-template-columns: 4fr 1fr;
-    
-}
-
-.ScenarioClockNoButtons {
-    justify-content: center;
-    align-content: center;
-    font-size: 22px;
-    display: grid;
-    grid-template-columns: 1fr;
-    vertical-align: center;
-    padding: 24px 20px 10px 20px;
+    padding: 10px 20px 10px 20px;
 }
 
 

--- a/ui/src/components/Page/Header.tsx
+++ b/ui/src/components/Page/Header.tsx
@@ -3,6 +3,7 @@ import { TbHelp } from "react-icons/tb";
 import './Header.css';
 import LocalClock from "./ClockModule/LocalClock";
 import ZuluClock from "./ClockModule/ZuluClock";
+import ScenarioClock from "./ClockModule/ScenarioClock";
 
 const Header = () => {
     const navigate = useNavigate();
@@ -20,7 +21,7 @@ const Header = () => {
             <div className="EWOK_Label">EWOK</div>
             <div className="LocalClock"><LocalClock /></div>
             <div className="ZuluClock"><ZuluClock /></div>
-            <div></div>
+            <div className="ScenarioClock"><ScenarioClock /></div>
             <div><TbHelp onClick={() => handleClickHelp()}/></div>
         </div>
     )

--- a/ui/src/components/Page/Header.tsx
+++ b/ui/src/components/Page/Header.tsx
@@ -1,5 +1,9 @@
 import { useNavigate, useLocation } from "react-router-dom";
 import { TbHelp } from "react-icons/tb";
+import './Header.css';
+import LocalClock from "./ClockModule/LocalClock";
+import ZuluClock from "./ClockModule/ZuluClock";
+
 const Header = () => {
     const navigate = useNavigate();
     const location = useLocation();
@@ -13,7 +17,10 @@ const Header = () => {
     }
     return(
         <div className="header" id='header'>
-            <div>EWOK</div>
+            <div className="EWOK_Label">EWOK</div>
+            <div className="LocalClock"><LocalClock /></div>
+            <div className="ZuluClock"><ZuluClock /></div>
+            <div></div>
             <div><TbHelp onClick={() => handleClickHelp()}/></div>
         </div>
     )

--- a/ui/src/components/Student/Transmitter.tsx
+++ b/ui/src/components/Student/Transmitter.tsx
@@ -3,6 +3,12 @@ import { useEwokContext, useEquipmentContext } from "../../context/EwokContext";
 import './Transmitter.css'
 
 const Transmitter = () => {
+    // LIMITS
+    const minFrequency = 800;
+    const maxFrequency = 2200;
+    const maxDataRate = 60;
+    const maxPower = -50
+
     const { equipment } = useEquipmentContext();
     const { socket } = useEwokContext();
     
@@ -15,28 +21,26 @@ const Transmitter = () => {
     useEffect(() => {
         tmpTX = [...equipment.filter(x => x.unit_type === 'TX' && x.unit_name === modem)][0];
         setTX(tmpTX);
-    }, [equipment, modem])
+    }, [equipment]);
 
     useEffect(() => {
-        setSettings(tx)
-    }, [tx])
+        tmpTX = [...equipment.filter(x => x.unit_type === 'TX' && x.unit_name === modem)][0];
+        setTX(tmpTX);
+        setSettings(tmpTX);
+    }, [modem]);
 
     const handleClickModem = (num: string) => {
         setModem(num);    
-    }
+    };
 
     const handlePlusPowerButton = (e: any) => {
         const tmpSettings = {
             ...settings,
-            power: settings.power + 1
+            power: Math.min(tx.power + 1, maxPower)
         };
         setSettings(tmpSettings);
         const tmpEquipment = {
             ...tx,
-            cf: tmpSettings.cf,
-            dr: tmpSettings.dr,
-            mod: tmpSettings.mod,
-            fec: tmpSettings.fec,
             power: tmpSettings.power
         }
         socket.emit('PATCH', 'equipment', tmpEquipment)
@@ -46,10 +50,10 @@ const Transmitter = () => {
                 server: tx.server,
                 conn: tx.conn,
                 team: tx.team,
-                cf: tmpSettings.cf,
-                dr: tmpSettings.dr,
-                mod: tmpSettings.mod,
-                fec: tmpSettings.fec,
+                cf: tx.cf,
+                dr: tx.dr,
+                mod: tx.mod,
+                fec: tx.fec,
                 power: tmpSettings.power,
                 band: tmpAntenna.unit_name,
                 sat: tmpAntenna.sat,
@@ -64,16 +68,12 @@ const Transmitter = () => {
 
     const handleMinusPowerButton = (e: any) => {
         const tmpSettings = {
-            ...settings,
-            power: settings.power - 1
+            ...tx,
+            power: tx.power - 1
         };
         setSettings(tmpSettings);
         const tmpEquipment = {
             ...tx,
-            cf: tmpSettings.cf,
-            dr: tmpSettings.dr,
-            mod: tmpSettings.mod,
-            fec: tmpSettings.fec,
             power: tmpSettings.power
         }
         socket.emit('PATCH', 'equipment', tmpEquipment)
@@ -83,10 +83,10 @@ const Transmitter = () => {
                 server: tx.server,
                 conn: tx.conn,
                 team: tx.team,
-                cf: tmpSettings.cf,
-                dr: tmpSettings.dr,
-                mod: tmpSettings.mod,
-                fec: tmpSettings.fec,
+                cf: tx.cf,
+                dr: tx.dr,
+                mod: tx.mod,
+                fec: tx.fec,
                 power: tmpSettings.power,
                 band: tmpAntenna.unit_name,
                 sat: tmpAntenna.sat,
@@ -102,21 +102,21 @@ const Transmitter = () => {
     const handleChangeCF = (e: any) => {
         const tmpSettings = {
             ...settings,
-            cf: Number(e.target.value)
+            cf: e.target.value
         };
         setSettings(tmpSettings);
     };
     const handleChangeDR = (e: any) => {
         const tmpSettings = {
             ...settings,
-            dr: Number(e.target.value)
+            dr: e.target.value
         };
         setSettings(tmpSettings);
     };
     const handleChangePower = (e: any) => {
         const tmpSettings = {
             ...settings,
-            power: Number(e.target.value)
+            power: e.target.value
         };
         setSettings(tmpSettings);
     };
@@ -128,6 +128,7 @@ const Transmitter = () => {
         };
         setSettings(tmpSettings);
     };
+
     const handleChangeMod = (e: any) => {
         const tmpSettings = {
             ...settings,
@@ -136,15 +137,38 @@ const Transmitter = () => {
         setSettings(tmpSettings);
     };
 
+    const handleClickReset = () => {
+        const tmpSettings = {...tx};
+        setSettings(tmpSettings);
+    };
 
     const handleClickUpdate = () => {
+        const cf = Number(settings.cf);
+        const dr = Number(settings.dr);
+        const power = Number(settings.power);
+
+        // Error handling for bad TX values
+        if ( isNaN(cf + dr + power) ) {
+            alert('Invalid TX value.')
+            return;
+        } else if ( cf < minFrequency || cf > maxFrequency ) {
+            alert('Frequency is outside of supported range.');
+            return;
+        } else if ( dr > maxDataRate ) {
+            alert('Data rate exceeds limits.');
+            return;
+        } else if ( power > maxPower ) {
+            alert('Power exceeds limits.')
+            return;
+        };
+        
         const tmpEquipment = {
             ...tx,
-            cf: settings.cf,
-            dr: settings.dr,
+            cf: cf,
+            dr: dr,
             mod: settings.mod,
             fec: settings.fec,
-            power: settings.power
+            power: power
         }
         socket.emit('PATCH', 'equipment', tmpEquipment)
         if(tx.active){
@@ -153,11 +177,11 @@ const Transmitter = () => {
                 server: tx.server,
                 conn: tx.conn,
                 team: tx.team,
-                cf: settings.cf,
-                dr: settings.dr,
+                cf: cf,
+                dr: dr,
                 mod: settings.mod,
                 fec: settings.fec,
-                power: settings.power,
+                power: power,
                 band: tmpAntenna.unit_name,
                 sat: tmpAntenna.sat,
                 feed: tx.feed,
@@ -265,10 +289,10 @@ const Transmitter = () => {
                 </div>       
                 <div className='txModemOutputs'>
                     <span className='label'>Frequency:</span>    
-                    <input type='text' value={settings?.cf} onChange={e => handleChangeCF(e)}></input>
+                    <input className={isNaN(settings?.cf) || settings?.cf < minFrequency || settings.cf > maxFrequency? "invalid" : ""} type='text' value={settings?.cf} onChange={e => handleChangeCF(e)}></input>
                     <span className='unit'>MHz</span>
                     <span className='label'>Data Rate:</span>    
-                    <input type='text' value={settings?.dr} onChange={e => handleChangeDR(e)}></input>
+                    <input type='text' className={isNaN(settings?.dr) || settings?.dr > maxDataRate ? "invalid" : ""} value={settings?.dr} onChange={e => handleChangeDR(e)}></input>
                     <span className='unit'>MHz</span>
                     <span className='label'>Modulation:</span>    
                     <select value={settings?.mod} onChange={e => handleChangeMod(e)}>
@@ -284,9 +308,9 @@ const Transmitter = () => {
                     </select>
                     <span className='unit'></span>
                     <span className='label'>Power:</span>    
-                    <input type='text' value={settings?.power} /*onKeyDown={e=>handleKeyDown(e)}*/ onChange={e => handleChangePower(e)}></input>
+                    <input className={isNaN(settings?.power) || settings.power > maxPower ? "invalid" : ""} type='text' value={settings?.power} /*onKeyDown={e=>handleKeyDown(e)}*/ onChange={e => handleChangePower(e)}></input>
                     <span className='unit'>dB</span>
-                    <span></span>
+                    <button onClick={() => handleClickReset()}>Reset</button>
                     <button onClick={() => handleClickUpdate()}>Update</button>
                 </div>   
             </div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -83,30 +83,6 @@ select {
   margin: .5em;
 }
 
-.header {
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100%;
-  align-items: center;
-  background-color: #393e47;
-  font-size: 30px;
-  display:grid;
-  grid-template-columns: 1fr 1fr;
-}
-
-.header * {
-  padding: 10px 20px 10px 20px;
-}
-
-.header :first-child {
-  text-align: left;
-}
-
-.header :last-child {
-  text-align: right;
-}
-
 .subheader {
   position: fixed;
   left: 0;


### PR DESCRIPTION
Okay Sir, I think you are going to like these changes. After some time this last week, I finally got the sockets working, which finally allowed me to get to work on making this happen. 

The Zulu and Local clocks were easy, thankfully. I went ahead and managed to make the Scenario clock work with the controls as well across the socket, with conditional rendering depending upon whether the ewok.team was "instructor" or not using the context instead of using Route.

Finally, I moved some of the header CSS attributes from the index.css as we discussed to its own header.css file in the components folder. You will also find a new folder named ClockModule, or something of the sort, which includes the zulu, local, and scenario clocks' TSX files. There is also a separate Scenario Clock CSS file to handle formatting because of the conditional rendering (whether Edit display is open or not).

I have bug tested this to the best of my knowledge and think it will be a worthwhile add-on to the Schoolhouse's version of EWOK. The only possible issue I think at the moment is that the socket sends out clock updates for all users regardless of the server. This can also be seen by the fact the Scenario Clock exists on the login screen. Perhaps this could be fixed in the future, but for now, with only one ENV being run on one IP address at a time, I don't see any conflicts between classes simultaneously using the program if that were to ever happen.

Let me know your thoughts, and I am happy to discuss this upcoming week as well. Also, if you approve of the additions and changes, I would love to hear any idea as to a timeline of implementation if that is something that could reasonably be provided. Thank you for letting me work on this so far.

- Lt Finley